### PR TITLE
Refactor version handling in BaseNukeBuildHelpers

### DIFF
--- a/NukeBuildHelpers/BaseNukeBuildHelpers.Helpers.cs
+++ b/NukeBuildHelpers/BaseNukeBuildHelpers.Helpers.cs
@@ -340,11 +340,25 @@ partial class BaseNukeBuildHelpers
                 throw new Exception("Entry id not found");
             }
 
+            SemVersion version;
+            if (SemVersion.TryParse(entry.Version, SemVersionStyles.Strict, out var parsedSemVersion))
+            {
+                version = parsedSemVersion;
+            }
+            else if (SemVersion.TryParse($"0.0.0-{entry.Environment}.0", SemVersionStyles.Strict, out var parsedMinSemVersion))
+            {
+                version = parsedMinSemVersion;
+            }
+            else
+            {
+                version = SemVersion.Parse($"0.0.0", SemVersionStyles.Strict);
+            }
+
             AppVersion appVersion = new()
             {
                 AppId = entry.AppId.NotNullOrEmpty(),
                 Environment = entry.Environment,
-                Version = SemVersion.Parse(entry.Version, SemVersionStyles.Strict),
+                Version = version,
                 BuildId = pipelinePreSetup.BuildId
             };
 

--- a/NukeBuildHelpers/BaseNukeBuildHelpers.Targets.Pipeline.cs
+++ b/NukeBuildHelpers/BaseNukeBuildHelpers.Targets.Pipeline.cs
@@ -280,7 +280,7 @@ partial class BaseNukeBuildHelpers
                 {
                     version = parsedSemVersion;
                 }
-                else if (SemVersion.TryParse($"0.0.0-{env}.0", SemVersionStyles.Strict, out var parsedMinSemVersion))
+                else if (SemVersion.TryParse($"0.0.0-{entry.Environment}.0", SemVersionStyles.Strict, out var parsedMinSemVersion))
                 {
                     version = parsedMinSemVersion;
                 }


### PR DESCRIPTION
#### PR Classification
Code enhancement to improve version handling in the `BaseNukeBuildHelpers` class.

#### PR Summary
This pull request introduces a new `version` variable that is assigned based on the parsing of `entry.Version`, with fallback logic to ensure a valid version is always set. 
- **BaseNukeBuildHelpers.Helpers.cs**: Added logic to parse `entry.Version` and fallback to a version based on `entry.Environment` if parsing fails.
- **BaseNukeBuildHelpers.Targets.Pipeline.cs**: Updated fallback version parsing to use `entry.Environment` instead of `env`.
