### PR TITLE
Fix errors when accessing env version data

### DIFF
--- a/NukeBuildHelpers/Entry/Helpers/EntryHelpers.cs
+++ b/NukeBuildHelpers/Entry/Helpers/EntryHelpers.cs
@@ -593,8 +593,11 @@ internal static class EntryHelpers
         foreach (var env in envs)
         {
             var envLower = env.ToLowerInvariant();
+            if (!allVersions.EnvVersionGrouped.TryGetValue(envLower, out var envVersions))
+            {
+                envVersions = [];
+            }
             var envVersionFile = allVersions.EnvVersionFileMap[envLower];
-            var envVersions = allVersions.EnvVersionGrouped[envLower];
             var latestEnvVersion = envVersions.Last();
             if (latestEnvVersion.ComparePrecedenceTo(envVersionFile) > 0)
             {

--- a/NukeBuildHelpers/Entry/Helpers/EntryHelpers.cs
+++ b/NukeBuildHelpers/Entry/Helpers/EntryHelpers.cs
@@ -595,7 +595,7 @@ internal static class EntryHelpers
             var envLower = env.ToLowerInvariant();
             if (!allVersions.EnvVersionGrouped.TryGetValue(envLower, out var envVersions))
             {
-                envVersions = [];
+                continue;
             }
             var envVersionFile = allVersions.EnvVersionFileMap[envLower];
             var latestEnvVersion = envVersions.Last();


### PR DESCRIPTION
#### PR Classification
Bug fix to prevent errors when accessing environment version data.

#### PR Summary
This pull request adds a check to ensure that the environment version data exists before attempting to access it, preventing potential runtime errors. 
- EntryHelpers.cs: Added a check for the existence of the environment entry in `allVersions.EnvVersionGrouped` before processing.
