### PR TITLE
Refactor build ID handling to use Git directly

### DIFF
--- a/NukeBuildHelpers/BaseNukeBuildHelpers.Targets.Pipeline.cs
+++ b/NukeBuildHelpers/BaseNukeBuildHelpers.Targets.Pipeline.cs
@@ -50,7 +50,7 @@ partial class BaseNukeBuildHelpers
 
             Dictionary<string, AppRunEntry> toEntry = [];
 
-            string buildIdStr = GitTasks.Git("show -s --format=%ct.%h HEAD").FirstOrDefault().Text?.Trim() ?? "";
+            string buildIdStr = GitTasks.Git("show -s --date=format:%Y%m%d --format=%cd.%h --abbrev=12 HEAD").FirstOrDefault().Text?.Trim() ?? "";
             if (string.IsNullOrWhiteSpace(buildIdStr))
                 throw new Exception("Failed to get build id from git.");
 

--- a/NukeBuildHelpers/Entry/Definitions/WorkflowConfigEntryDefinition.cs
+++ b/NukeBuildHelpers/Entry/Definitions/WorkflowConfigEntryDefinition.cs
@@ -40,13 +40,6 @@ internal class WorkflowConfigEntryDefinition : IWorkflowConfigEntryDefinition
         set => enablePrereleaseOnReleases = value;
     }
 
-    Func<Task<long>>? startingBuildId = null;
-    Func<Task<long>> IWorkflowConfigEntryDefinition.StartingBuildId
-    {
-        get => startingBuildId ?? (() => Task.FromResult(1L));
-        set => startingBuildId = value;
-    }
-
     Func<Task<bool>>? useJsonFileVersioning = null;
     Func<Task<bool>> IWorkflowConfigEntryDefinition.UseJsonFileVersioning
     {
@@ -62,7 +55,6 @@ internal class WorkflowConfigEntryDefinition : IWorkflowConfigEntryDefinition
         if (postSetupRunnerOS != null) ((IWorkflowConfigEntryDefinition)this).PostSetupRunnerOS = postSetupRunnerOS;
         if (appendReleaseNotesAssetHashes != null) ((IWorkflowConfigEntryDefinition)this).AppendReleaseNotesAssetHashes = appendReleaseNotesAssetHashes;
         if (enablePrereleaseOnReleases != null) ((IWorkflowConfigEntryDefinition)this).EnablePrereleaseOnRelease = enablePrereleaseOnReleases;
-        if (startingBuildId != null) ((IWorkflowConfigEntryDefinition)this).StartingBuildId = startingBuildId;
         if (useJsonFileVersioning != null) ((IWorkflowConfigEntryDefinition)this).UseJsonFileVersioning = useJsonFileVersioning;
         return definition;
     }

--- a/NukeBuildHelpers/Entry/Extensions/WorkflowConfigEntryExtensions.cs
+++ b/NukeBuildHelpers/Entry/Extensions/WorkflowConfigEntryExtensions.cs
@@ -219,48 +219,6 @@ public static class WorkflowConfigEntryExtensions
     }
 
     /// <summary>
-    /// Sets the starting build ID for the workflow.
-    /// </summary>
-    /// <typeparam name="TWorkflowConfigEntryDefinition">The type of the workflow entry definition.</typeparam>
-    /// <param name="definition">The workflow entry definition instance.</param>
-    /// <param name="startingBuildId">The starting build ID to set.</param>
-    /// <returns>The modified workflow entry definition instance.</returns>
-    public static TWorkflowConfigEntryDefinition StartingBuildId<TWorkflowConfigEntryDefinition>(this TWorkflowConfigEntryDefinition definition, long startingBuildId)
-        where TWorkflowConfigEntryDefinition : IWorkflowConfigEntryDefinition
-    {
-        definition.StartingBuildId = () => Task.Run(() => startingBuildId);
-        return definition;
-    }
-
-    /// <summary>
-    /// Sets the starting build ID using a function for the workflow.
-    /// </summary>
-    /// <typeparam name="TWorkflowConfigEntryDefinition">The type of the workflow entry definition.</typeparam>
-    /// <param name="definition">The workflow entry definition instance.</param>
-    /// <param name="startingBuildId">A function returning the starting build ID.</param>
-    /// <returns>The modified workflow entry definition instance.</returns>
-    public static TWorkflowConfigEntryDefinition StartingBuildId<TWorkflowConfigEntryDefinition>(this TWorkflowConfigEntryDefinition definition, Func<long> startingBuildId)
-        where TWorkflowConfigEntryDefinition : IWorkflowConfigEntryDefinition
-    {
-        definition.StartingBuildId = () => Task.Run(() => startingBuildId());
-        return definition;
-    }
-
-    /// <summary>
-    /// Sets the starting build ID using an asynchronous function for the workflow.
-    /// </summary>
-    /// <typeparam name="TWorkflowConfigEntryDefinition">The type of the workflow entry definition.</typeparam>
-    /// <param name="definition">The workflow entry definition instance.</param>
-    /// <param name="startingBuildId">An asynchronous function returning the starting build ID.</param>
-    /// <returns>The modified workflow entry definition instance.</returns>
-    public static TWorkflowConfigEntryDefinition StartingBuildId<TWorkflowConfigEntryDefinition>(this TWorkflowConfigEntryDefinition definition, Func<Task<long>> startingBuildId)
-        where TWorkflowConfigEntryDefinition : IWorkflowConfigEntryDefinition
-    {
-        definition.StartingBuildId = () => Task.Run(async () => await startingBuildId());
-        return definition;
-    }
-
-    /// <summary>
     /// Configures whether to use JSON file versioning in the workflow. If enabled, a file named <c>versions.json</c> will be generated in the <see cref="Nuke.Common.NukeBuild.RootDirectory"/> on every build workflow generation.
     /// </summary>
     /// <typeparam name="TWorkflowConfigEntryDefinition">The type of the workflow entry definition.</typeparam>

--- a/NukeBuildHelpers/Entry/Interfaces/IWorkflowConfigEntryDefinition.cs
+++ b/NukeBuildHelpers/Entry/Interfaces/IWorkflowConfigEntryDefinition.cs
@@ -20,8 +20,6 @@ public interface IWorkflowConfigEntryDefinition
 
     internal Func<Task<bool>> EnablePrereleaseOnRelease { get; set; }
 
-    internal Func<Task<long>> StartingBuildId { get; set; }
-
     internal Func<Task<bool>> UseJsonFileVersioning { get; set; }
 
     internal async Task<string> GetName()
@@ -47,11 +45,6 @@ public interface IWorkflowConfigEntryDefinition
     internal async Task<bool> GetEnablePrereleaseOnReleases()
     {
         return await EnablePrereleaseOnRelease();
-    }
-
-    internal async Task<long> GetStartingBuildId()
-    {
-        return await StartingBuildId();
     }
 
     internal async Task<bool> GetUseJsonFileVersioning()

--- a/NukeBuildHelpers/Entry/Models/AllVersions.cs
+++ b/NukeBuildHelpers/Entry/Models/AllVersions.cs
@@ -4,7 +4,7 @@ namespace NukeBuildHelpers.Entry.Models;
 
 internal class AllVersions
 {
-    public required Dictionary<string, List<long>> CommitBuildIdGrouped { get; init; }
+    public required Dictionary<string, List<string>> CommitBuildIdGrouped { get; init; }
 
     public required Dictionary<string, List<SemVersion>> CommitVersionGrouped { get; init; }
 
@@ -12,15 +12,15 @@ internal class AllVersions
 
     public required Dictionary<SemVersion, string> VersionCommitPaired { get; init; }
 
-    public required Dictionary<long, string> BuildIdCommitPaired { get; init; }
+    public required Dictionary<string, string> BuildIdCommitPaired { get; init; }
 
     public required Dictionary<string, List<SemVersion>> EnvVersionGrouped { get; init; }
 
-    public required Dictionary<string, List<long>> EnvBuildIdGrouped { get; init; }
+    public required Dictionary<string, List<string>> EnvBuildIdGrouped { get; init; }
 
     public required Dictionary<string, SemVersion> EnvLatestVersionPaired { get; init; }
 
-    public required Dictionary<string, long> EnvLatestBuildIdPaired { get; init; }
+    public required Dictionary<string, string> EnvLatestBuildIdPaired { get; init; }
 
     public required List<string> EnvSorted { get; init; }
 

--- a/NukeBuildHelpers/Entry/Models/AppVersion.cs
+++ b/NukeBuildHelpers/Entry/Models/AppVersion.cs
@@ -25,5 +25,5 @@ public class AppVersion
     /// <summary>
     /// Gets the build ID associated with the version.
     /// </summary>
-    public required long BuildId { get; init; }
+    public required string BuildId { get; init; }
 }

--- a/NukeBuildHelpers/Pipelines/Common/Models/PipelinePreSetup.cs
+++ b/NukeBuildHelpers/Pipelines/Common/Models/PipelinePreSetup.cs
@@ -9,9 +9,9 @@ internal class PipelinePreSetup
 
     public required TriggerType TriggerType { get; init; }
 
-    public required long BuildId { get; init; }
+    public required string BuildId { get; init; }
 
-    public required long LastBuildId { get; init; }
+    public required string LastBuildId { get; init; }
 
     public required string Environment { get; init; }
 

--- a/docs/WorkflowConfigEntry.md
+++ b/docs/WorkflowConfigEntry.md
@@ -24,7 +24,6 @@ class Build : BaseNukeBuildHelpers
 - [PostSetupRunnerOS](#postsetuprunneros)
 - [AppendReleaseNotesAssetHashes](#appendreleasenotesassethashes)
 - [EnablePrereleaseOnRelease](#enableprereleaseonrelease)
-- [StartingBuildId](#startingbuildid)
 - [UseJsonFileVersioning](#usejsonfileversioning)
 
 ---
@@ -249,48 +248,6 @@ IWorkflowConfigEntryDefinition EnablePrereleaseOnRelease(Func<Task<bool>> enable
     }
     ```
     
-## StartingBuildId
-
-Sets the starting build ID for the workflow. Default is `1`.
-
-### Definitions
-
-```csharp
-IWorkflowConfigEntryDefinition StartingBuildId(long startingBuildId)
-IWorkflowConfigEntryDefinition StartingBuildId(Func<long> startingBuildId)
-IWorkflowConfigEntryDefinition StartingBuildId(Func<Task<long>> startingBuildId)
-```
-
-### Usage
-
-* Specify directly
-
-    ```csharp
-    using NukeBuildHelpers.Entry.Extensions;
-
-    class Build : BaseNukeBuildHelpers
-    {
-        ...
-        
-        WorkflowConfigEntry SampleConfigEntry => _ => _
-            .StartingBuildId(123);
-    }
-    ```
-
-* Use an asynchronous function
-
-    ```csharp
-    using NukeBuildHelpers.Entry.Extensions;
-
-    class Build : BaseNukeBuildHelpers
-    {
-        ...
-        
-        WorkflowConfigEntry SampleConfigEntry => _ => _
-            .StartingBuildId(async () => await Task.FromResult(123));
-    }
-    ```
-
 ## UseJsonFileVersioning
 
 Configures whether to use JSON file versioning in the workflow. If enabled, a file named `versions.json` will be generated in the root directory on every build workflow generation.


### PR DESCRIPTION
#### PR Classification
Refactor to streamline build ID management by integrating Git operations.

#### PR Summary
This pull request refactors the build ID management system to utilize Git for retrieving build IDs, transitioning from long to string types for IDs, and simplifying the related interfaces and data structures. 
- **BaseNukeBuildHelpers.Targets.Pipeline.cs**: Added Git dependency and replaced long-based build ID logic with string retrieval from Git.
- **IWorkflowConfigEntryDefinition.cs**: Removed methods related to starting build IDs, simplifying the interface.
- **AllVersions.cs**: Updated data structures to accommodate string-based build IDs.
- **EntryHelpers.cs**: Adjusted logic to ensure compatibility with the new string-based ID handling.
- **Documentation**: Updated to reflect the removal of the `StartingBuildId` functionality.
