### PR TITLE
Update Git command to shorten commit hash abbreviation

### DIFF
--- a/NukeBuildHelpers/BaseNukeBuildHelpers.Targets.Pipeline.cs
+++ b/NukeBuildHelpers/BaseNukeBuildHelpers.Targets.Pipeline.cs
@@ -50,7 +50,7 @@ partial class BaseNukeBuildHelpers
 
             Dictionary<string, AppRunEntry> toEntry = [];
 
-            string buildIdStr = GitTasks.Git("show -s --date=format:%Y%m%d%H%M%S --format=%cd.%h --abbrev=8 HEAD").FirstOrDefault().Text?.Trim() ?? "";
+            string buildIdStr = GitTasks.Git("show -s --date=format:%Y%m%d%H%M%S --format=%cd.%h --abbrev=7 HEAD").FirstOrDefault().Text?.Trim() ?? "";
             if (string.IsNullOrWhiteSpace(buildIdStr))
                 throw new Exception("Failed to get build id from git.");
 


### PR DESCRIPTION
#### PR Classification
Code cleanup to improve the retrieval of the build ID from Git.

#### PR Summary
This pull request updates the Git command used to fetch the build ID by changing the commit hash abbreviation from 8 to 7 characters. 
- `BaseNukeBuildHelpers.Targets.Pipeline.cs`: Modified the `buildIdStr` assignment to use `--abbrev=7` instead of `--abbrev=8`.
