### PR TITLE
Update .NET support and enhance task resilience

### DIFF
--- a/NukeBuildHelpers/NukeBuildHelpers.csproj
+++ b/NukeBuildHelpers/NukeBuildHelpers.csproj
@@ -5,7 +5,6 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>13</LangVersion>
 		<Nullable>enable</Nullable>
-		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 	</PropertyGroup>


### PR DESCRIPTION
Update .NET support and enhance task resilience

- Updated `TargetFrameworks` in `NukeBuildHelpers.csproj` to include `net9.0` and removed `CopyLocalLockFileAssemblies`.
- Added new `using` directives in `Build.cs` for additional functionality.
- Introduced `RetryTask<T>` method in the `Build` class for executing tasks with a retry mechanism.
- Refactored calls to `DotNetTasks.DotNetClean`, `DotNetTasks.DotNetTest`, `DotNetTasks.DotNetBuild`, and `DotNetTasks.DotNetPack` to utilize the new retry mechanism.
- Updated `DotNetTasks.DotNetNuGetPush` to use the retry method and changed the NuGet source URL.
- Overall improvements to error handling and resilience in the build process.